### PR TITLE
remove use of EventCounter from legacy scripts and fix a crash

### DIFF
--- a/FCCSW_ecal/fcc_ee_samplingFraction_inclinedEcal.py
+++ b/FCCSW_ecal/fcc_ee_samplingFraction_inclinedEcal.py
@@ -1,5 +1,4 @@
 from Configurables import ApplicationMgr
-from Configurables import EventCounter
 from Configurables import PodioOutput
 from Configurables import AuditorSvc, ChronoAuditor
 from Configurables import SamplingFractionInLayers
@@ -116,11 +115,8 @@ out = PodioOutput("out", OutputLevel=INFO)
 out.outputCommands = ["drop *"]
 out.filename = "fccee_samplingFraction_inclinedEcal.root"
 
-event_counter = EventCounter('event_counter')
-event_counter.Frequency = 10
-
 # ApplicationMgr
-ApplicationMgr(TopAlg=[event_counter, genalg_pgun, hepmc_converter, geantsim, hist, out],
+ApplicationMgr(TopAlg=[genalg_pgun, hepmc_converter, geantsim, hist, out],
                EvtSel='NONE',
                EvtMax=100,
                # order is important, as GeoSvc is needed by G4SimSvc

--- a/FCCSW_ecal/fcc_ee_samplingFraction_inclinedEcal_ddsim.py
+++ b/FCCSW_ecal/fcc_ee_samplingFraction_inclinedEcal_ddsim.py
@@ -1,5 +1,4 @@
 from Configurables import ApplicationMgr
-from Configurables import EventCounter
 from Configurables import k4DataSvc, PodioInput
 from Configurables import PodioOutput
 from Configurables import AuditorSvc, ChronoAuditor
@@ -85,11 +84,8 @@ out = PodioOutput("out", OutputLevel=INFO)
 out.outputCommands = ["drop *"]
 out.filename = "fccee_samplingFraction_inclinedEcal.root"
 
-event_counter = EventCounter('event_counter')
-event_counter.Frequency = 10
-
 # ApplicationMgr
-ApplicationMgr(TopAlg=[event_counter, input_reader, hist, out],
+ApplicationMgr(TopAlg=[input_reader, hist, out],
                EvtSel='NONE',
                EvtMax=-1,
                # order is important, as GeoSvc is needed by G4SimSvc

--- a/FCCSW_ecal/fcc_ee_upstream_with_clusters.py
+++ b/FCCSW_ecal/fcc_ee_upstream_with_clusters.py
@@ -216,14 +216,9 @@ out = PodioOutput("out",OutputLevel=INFO)
 out.outputCommands = ["keep *", "drop ECalBarrel*", "drop emptyCaloCells"]
 out.filename = "fccee_deadMaterial_inclinedEcal.root"
 
-from Configurables import EventCounter
-event_counter = EventCounter('event_counter')
-event_counter.Frequency = 10
-
 # ApplicationMgr
 from Configurables import ApplicationMgr
 ApplicationMgr( TopAlg = [
-    event_counter,
     genalg_pgun,
     hepmc_converter,
     geantsim,

--- a/FCCSW_ecal/runClueAndTopoAndSlidingWindowAndCaloSim.py
+++ b/FCCSW_ecal/runClueAndTopoAndSlidingWindowAndCaloSim.py
@@ -476,14 +476,9 @@ createTopoClusters.AuditExecute = True
 createClueClusters.AuditExecute = True 
 out.AuditExecute = True
 
-from Configurables import EventCounter
-event_counter = EventCounter('event_counter')
-event_counter.Frequency = 10
-
 from Configurables import ApplicationMgr
 ApplicationMgr(
     TopAlg = [
-              event_counter,
               genAlg,
               hepmc_converter,
               geantsim,

--- a/FCCSW_ecal/runFullSim.py
+++ b/FCCSW_ecal/runFullSim.py
@@ -402,14 +402,9 @@ cell_creator_to_use.AuditExecute = True
 #createHcalBarrelCells.AuditExecute = True
 out.AuditExecute = True
 
-from Configurables import EventCounter
-event_counter = EventCounter('event_counter')
-event_counter.Frequency = 10
-
 from Configurables import ApplicationMgr
 ApplicationMgr(
     TopAlg = [
-              event_counter,
               genAlg,
               hepmc_converter,
               geantsim,

--- a/FCCSW_ecal/runSlidingWindowAndCaloSim.py
+++ b/FCCSW_ecal/runSlidingWindowAndCaloSim.py
@@ -352,14 +352,9 @@ cell_creator_to_use.AuditExecute = True
 #createHcalBarrelCells.AuditExecute = True
 out.AuditExecute = True
 
-from Configurables import EventCounter
-event_counter = EventCounter('event_counter')
-event_counter.Frequency = 10
-
 from Configurables import ApplicationMgr
 ApplicationMgr(
     TopAlg = [
-              event_counter,
               genAlg,
               hepmc_converter,
               geantsim,

--- a/FCCSW_ecal/runTopoAndSlidingWindowAndCaloSim.py
+++ b/FCCSW_ecal/runTopoAndSlidingWindowAndCaloSim.py
@@ -456,14 +456,9 @@ cell_creator_to_use.AuditExecute = True
 createTopoClusters.AuditExecute = True 
 out.AuditExecute = True
 
-from Configurables import EventCounter
-event_counter = EventCounter('event_counter')
-event_counter.Frequency = 10
-
 from Configurables import ApplicationMgr
 ApplicationMgr(
     TopAlg = [
-              event_counter,
               genAlg,
               hepmc_converter,
               geantsim,

--- a/FCCSW_ecal/run_thetamodulemerged.py
+++ b/FCCSW_ecal/run_thetamodulemerged.py
@@ -2,7 +2,6 @@
 # IMPORTS
 #
 from Configurables import ApplicationMgr
-from Configurables import EventCounter
 from Configurables import AuditorSvc, ChronoAuditor
 # Event generation
 from Configurables import GenAlg
@@ -26,6 +25,7 @@ from Configurables import CreateEmptyCaloCellsCollection
 # Cell positioning tools
 from Configurables import CreateCaloCellPositionsFCCee
 from Configurables import CellPositionsECalBarrelModuleThetaSegTool
+from Configurables import CellPositionsECalEndcapTurbineSegTool
 # Redo segmentation for ECAL and HCAL
 from Configurables import RedoSegmentation
 # Read noise values from file and generate noise in cells
@@ -291,13 +291,14 @@ saveECalBarrelTool = SimG4SaveCalHits(
 )
 saveECalBarrelTool.CaloHits.Path = ecalBarrelHitsName
 
-# - ECAL encap
+# - ECAL endcap
+ecalEndcapHitsName = "ECalEndcapPositionedHits"
 saveECalEndcapTool = SimG4SaveCalHits(
     "saveECalEndcapHits",
     readoutName=ecalEndcapReadoutName,
     OutputLevel=INFO
 )
-saveECalEndcapTool.CaloHits.Path = "ECalEndcapHits"
+saveECalEndcapTool.CaloHits.Path = ecalEndcapHitsName
 
 if runHCal:
     # - HCAL barrel
@@ -346,9 +347,11 @@ calibEcalBarrel = CalibrateInLayersTool("CalibrateECalBarrel",
                                         readoutName=ecalBarrelReadoutName,
                                         layerFieldName="layer")
 
-# - ECAL endcap (TO BE UPDATED)
-calibEcalEndcap = CalibrateCaloHitsTool(
-    "CalibrateECalEndcap", invSamplingFraction="4.27")
+# - ECAL endcap
+calibEcalEndcap = CalibrateInLayersTool("CalibrateECalEndcap",
+                                        samplingFraction = [0.16419] * 1 + [0.192898] * 1 + [0.18783] * 1 + [0.193203] * 1 + [0.193928] * 1 + [0.192286] * 1 + [0.199959] * 1 + [0.200153] * 1 + [0.212635] * 1 + [0.180345] * 1 + [0.18488] * 1 + [0.194762] * 1 + [0.197775] * 1 + [0.200504] * 1 + [0.205555] * 1 + [0.203601] * 1 + [0.210877] * 1 + [0.208376] * 1 + [0.216345] * 1 + [0.201452] * 1 + [0.202134] * 1 + [0.207566] * 1 + [0.208152] * 1 + [0.209889] * 1 + [0.211743] * 1 + [0.213188] * 1 + [0.215864] * 1 + [0.22972] * 1 + [0.192515] * 1 + [0.0103233] * 1,
+                                        readoutName=ecalEndcapReadoutName,
+                                        layerFieldName="layer")
 
 if runHCal:
     # - HCAL barrel
@@ -434,14 +437,31 @@ createEcalBarrelPositionedCells2.positionedHits.Path = "ECalBarrelPositionedCell
 
 
 # Create cells in ECal endcap
+ecalEndcapCellsName = "ECalEndcapCells"
 createEcalEndcapCells = CreateCaloCells("CreateEcalEndcapCaloCells",
                                         doCellCalibration=True,
                                         calibTool=calibEcalEndcap,
                                         addCellNoise=False,
                                         filterCellNoise=False,
-                                        OutputLevel=INFO)
-createEcalEndcapCells.hits.Path = "ECalEndcapHits"
-createEcalEndcapCells.cells.Path = "ECalEndcapCells"
+                                        OutputLevel=INFO,
+                                        hits=ecalEndcapHitsName,
+                                        cells=ecalEndcapCellsName)
+
+# Add to Ecal endcap cells the position information
+# (good for physics, all coordinates set properly)
+cellPositionEcalEndcapTool = CellPositionsECalEndcapTurbineSegTool(
+    "CellPositionsECalEndcap",
+    readoutName=ecalEndcapReadoutName,
+    OutputLevel=INFO
+)
+ecalEndcapPositionedCellsName = "ECalEndcapPositionedCells"
+createEcalEndcapPositionedCells = CreateCaloCellPositionsFCCee(
+    "CreateECalEndcapPositionedCells",
+    OutputLevel=INFO
+)
+createEcalEndcapPositionedCells.positionsTool = cellPositionEcalEndcapTool
+createEcalEndcapPositionedCells.hits.Path = ecalEndcapCellsName
+createEcalEndcapPositionedCells.positionedHits.Path = ecalEndcapPositionedCellsName
 
 if addNoise:
     ecalBarrelNoisePath = os.environ['FCCBASEDIR']+"/LAr_scripts/data/elecNoise_ecalBarrelFCCee_theta.root"
@@ -604,7 +624,7 @@ if doSWClustering:
                                 hcalFwdReadoutName="",
                                 OutputLevel=INFO)
     towers.ecalBarrelCells.Path = ecalBarrelPositionedCellsName
-    towers.ecalEndcapCells.Path = "ECalEndcapCells"
+    towers.ecalEndcapCells.Path = ecalEndcapPositionedCellsName
     towers.ecalFwdCells.Path = "emptyCaloCells"
     towers.hcalBarrelCells.Path = hcalBarrelPositionedCellsName2
     towers.hcalExtBarrelCells.Path = "emptyCaloCells"
@@ -847,15 +867,11 @@ if doTopoClustering:
     createTopoClusters.AuditExecute = True
 out.AuditExecute = True
 
-event_counter = EventCounter('event_counter')
-event_counter.Frequency = 10
-
 ExtSvc = [geoservice, podioevent, geantservice, audsvc]
 if dumpGDML:
     ExtSvc += [gdmldumpservice]
 
 TopAlg = [
-    event_counter,
     genAlg,
     hepmc_converter,
     geantsim,
@@ -864,7 +880,8 @@ TopAlg = [
     resegmentEcalBarrel,
     createEcalBarrelCells2,
     createEcalBarrelPositionedCells2,
-    createEcalEndcapCells
+    createEcalEndcapCells,
+    createEcalEndcapPositionedCells,
 ]
 
 if runHCal:

--- a/FCCSW_ecal/tau_runTopoAndSlidingWindowAndCaloSim.py
+++ b/FCCSW_ecal/tau_runTopoAndSlidingWindowAndCaloSim.py
@@ -436,14 +436,9 @@ cell_creator_to_use.AuditExecute = True
 createTopoClusters.AuditExecute = True 
 out.AuditExecute = True
 
-from Configurables import EventCounter
-event_counter = EventCounter('event_counter')
-event_counter.Frequency = 1
-
 from Configurables import ApplicationMgr
 ApplicationMgr(
     TopAlg = [
-              event_counter,
               genAlg,
               hepmc_converter,
               geantsim,


### PR DESCRIPTION
Remove use of EventCounter in legacy scripts
Add cell calibration and positioning tool for ecal endcap cells